### PR TITLE
Add tests for GroupsController index and show actions

### DIFF
--- a/test/controllers/group_controller_test.rb
+++ b/test/controllers/group_controller_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class GroupControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -5,17 +5,28 @@ class GroupsControllerTest < ActionDispatch::IntegrationTest
 
   setup do
     @user = users(:one)
-    sign_in @user
     @group = groups(:one)
   end
 
-  test "should get index" do
+  test "should get index when signed in" do
+    sign_in @user
     get groups_url
     assert_response :success
   end
 
-  test "should show group" do
+  test "should redirect index when not signed in" do
+    get groups_url
+    assert_redirected_to new_user_session_path
+  end
+
+  test "should show group when signed in" do
+    sign_in @user
     get group_url(@group)
     assert_response :success
+  end
+
+  test "should redirect show when not signed in" do
+    get group_url(@group)
+    assert_redirected_to new_user_session_path
   end
 end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class GroupsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    sign_in @user
+    @group = groups(:one)
+  end
+
+  test "should get index" do
+    get groups_url
+    assert_response :success
+  end
+
+  test "should show group" do
+    get group_url(@group)
+    assert_response :success
+  end
+end

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,0 +1,2 @@
+one:
+  name: Test Category

--- a/test/fixtures/cities.yml
+++ b/test/fixtures/cities.yml
@@ -1,0 +1,2 @@
+one:
+  name: Test City

--- a/test/fixtures/groups.yml
+++ b/test/fixtures/groups.yml
@@ -1,0 +1,6 @@
+one:
+  title: Test Group
+  description: Sample group description
+  user: one
+  city: one
+  category: one

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,3 @@
+one:
+  email: user@example.com
+  encrypted_password: <%= Devise::Encryptor.digest(User, 'password') %>


### PR DESCRIPTION
## Summary
- rename `group_controller_test` to `groups_controller_test`
- add index and show action tests for groups
- create fixtures for users, cities, categories, and groups

## Testing
- `bin/rails test test/controllers/groups_controller_test.rb` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689b2fad5f10832ba980e428add99272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Added integration tests for group listing and details with authentication, verifying access for signed-in users and redirects for guests.
  - Introduced test data for users, groups, categories, and cities to support scenarios.
  - Removed obsolete controller test scaffold.
- Chores
  - Consolidated controller test naming to align with current routing conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->