### PR TITLE
Clarify authorization in group filter

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -22,7 +22,7 @@ class GroupsController < ApplicationController
     end
 
     render partial: "groups/list", locals: { groups: @groups }, formats: [:html]
-    # authorize @group
+    # No authorization needed; this action only filters public groups
   end
 
   def join


### PR DESCRIPTION
## Summary
- clarify group filtering authorization comment

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `bundle exec rails test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b2fab724c832ba21f382fe5eb335e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified comments around group filtering to note that authorization isn’t required when filtering public groups. No functional changes.
* **Chores**
  * No user-facing changes; group filtering behavior and results remain the same. No updates to UI, endpoints, or permissions; performance and outputs are identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->