### PR TITLE
Fix wrapper class typo in group show view

### DIFF
--- a/app/views/groups/show.html.erb
+++ b/app/views/groups/show.html.erb
@@ -25,7 +25,7 @@
         <p><i id="i-t"  class="fa-solid fa-quote-right"></i><%= @group.category.name%></p>
         <p><em>Public</em></p>
 
-      <div class="wrappper">
+      <div class="wrapper">
         <nav class="menuShare" data-controller="share">
           <input type="checkbox" id="menu-open" class="menu-open" name="menu-open" />
           <label for="menu-open" class="menu-open-button">


### PR DESCRIPTION
## Summary
- fix wrapper class name typo in groups show page

## Testing
- `bin/rails test` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_689b2fa9296c832bb2f7299e9e7bc0cb