### PR TITLE
Avoid exceptions on failed record creation

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,7 +6,7 @@ class CommentsController < ApplicationController
     @comment.user_id = current_user.id
     @comment.post_id = params["post_id"]
     @post = Post.find(params["post_id"])
-    if @comment.save!
+    if @comment.save
       respond_to do |format|
         format.html { redirect_to post_path(@comment.post_id), notice: 'comment was successfully created.' }
         format.text { render partial: "posts/comments", locals: { post: @post }, formats: [:html] }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -49,7 +49,7 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
     @group.user_id = current_user.id
-    if @group.save!
+    if @group.save
       redirect_to @group, notice: 'Group was successfully created.'
     else
       render :new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,7 +6,7 @@ class PostsController < ApplicationController
     @post.user_id = current_user.id
     @post.group_id = params["group_id"]
     @group = Group.find(params["group_id"])
-    if @post.save!
+    if @post.save
       respond_to do |format|
         format.html { redirect_to group_path(@post.group_id), notice: 'Post was successfully created.' }
         format.text { render partial: "groups/posts", locals: {group: @group}, formats: [:html] }


### PR DESCRIPTION
## Summary
- fix controllers to use `save` instead of `save!` so failed validations don't raise

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_689b2ec754d0832ba343eadfd828aded