### PR TITLE
Avoid exceptions on failed record creation

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,7 +6,7 @@ class CommentsController < ApplicationController
     @comment.user_id = current_user.id
     @comment.post_id = params["post_id"]
     @post = Post.find(params["post_id"])
-    if @comment.save!
+    if @comment.save
       respond_to do |format|
         format.html { redirect_to post_path(@comment.post_id), notice: 'comment was successfully created.' }
         format.text { render partial: "posts/comments", locals: { post: @post }, formats: [:html] }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -13,6 +13,7 @@ class CommentsController < ApplicationController
       end
 
     else
+      @post = Post.find(params["post_id"])
       render :new
     end
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -49,7 +49,7 @@ class GroupsController < ApplicationController
   def create
     @group = Group.new(group_params)
     @group.user_id = current_user.id
-    if @group.save!
+    if @group.save
       redirect_to @group, notice: 'Group was successfully created.'
     else
       render :new

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -6,7 +6,7 @@ class PostsController < ApplicationController
     @post.user_id = current_user.id
     @post.group_id = params["group_id"]
     @group = Group.find(params["group_id"])
-    if @post.save!
+    if @post.save
       respond_to do |format|
         format.html { redirect_to group_path(@post.group_id), notice: 'Post was successfully created.' }
         format.text { render partial: "groups/posts", locals: {group: @group}, formats: [:html] }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,6 @@
 class Comment < ApplicationRecord
   belongs_to :user
   belongs_to :post
+
+  validates :content, presence: true
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -8,6 +8,8 @@ class Group < ApplicationRecord
   has_one_attached :photo
   has_many :meetings
 
+  validates :title, presence: true
+
   def category_name
     category.name
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,4 +3,6 @@ class Post < ApplicationRecord
   belongs_to :group
   has_many :comments, dependent: :destroy
   has_one_attached :photo
+
+  validates :content, presence: true
 end

--- a/app/views/comments/new.html.erb
+++ b/app/views/comments/new.html.erb
@@ -1,0 +1,14 @@
+<h1>New Comment</h1>
+<%= form_with model: @comment, url: post_comments_path(@post) do |form| %>
+  <% if @comment.errors.any? %>
+    <div id="error_explanation">
+      <ul>
+      <% @comment.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= form.text_area :content %>
+  <%= form.submit %>
+<% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,14 @@
+<h1>New Post</h1>
+<%= form_with model: @post, url: group_posts_path(@group) do |form| %>
+  <% if @post.errors.any? %>
+    <div id="error_explanation">
+      <ul>
+      <% @post.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+  <%= form.text_area :content %>
+  <%= form.submit %>
+<% end %>

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -1,7 +1,22 @@
 require "test_helper"
 
 class CommentsControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  include Devise::Test::IntegrationHelpers
+
+  test "invalid comment params render new with errors" do
+    user = User.create!(email: "user@example.com", password: "password")
+    sign_in user
+    category = Category.create!(name: "Sports")
+    city = City.create!(name: "Metropolis")
+    group = Group.create!(title: "Group", description: "desc", user: user, category: category, city: city)
+    post_record = Post.create!(content: "hello", user: user, group: group)
+
+    assert_no_difference("Comment.count") do
+      post post_comments_path(post_record), params: { comment: { content: "" } }
+    end
+
+    assert_response :success
+    assert_template :new
+    assert_select "#error_explanation"
+  end
 end

--- a/test/controllers/group_controller_test.rb
+++ b/test/controllers/group_controller_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class GroupControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/controllers/groups_controller_test.rb
+++ b/test/controllers/groups_controller_test.rb
@@ -1,17 +1,16 @@
 require "test_helper"
 
-class PostsControllerTest < ActionDispatch::IntegrationTest
+class GroupsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test "invalid post params render new with errors" do
+  test "invalid group params renders new with errors" do
     user = User.create!(email: "user@example.com", password: "password")
     sign_in user
     category = Category.create!(name: "Sports")
     city = City.create!(name: "Metropolis")
-    group = Group.create!(title: "Group", description: "desc", user: user, category: category, city: city)
 
-    assert_no_difference("Post.count") do
-      post group_posts_path(group), params: { post: { content: "" } }
+    assert_no_difference("Group.count") do
+      post groups_path, params: { group: { title: "", description: "desc", category_id: category.id, city_id: city.id } }
     end
 
     assert_response :success


### PR DESCRIPTION
## Summary
- fix controllers to use `save` instead of `save!` so failed validations don't raise

## Testing
- `bundle exec rails test` *(fails: bundler: command not found: rails)*
- `bundle install` *(fails: Your Ruby version is 3.2.3, but your Gemfile specified 3.1.2)*

------
https://chatgpt.com/codex/tasks/task_e_689b2ec754d0832ba343eadfd828aded